### PR TITLE
LWDEV-7938 - Change public api clients to Refit.

### DIFF
--- a/src/Lykke.HttpClientGenerator/AutofacExtensions.cs
+++ b/src/Lykke.HttpClientGenerator/AutofacExtensions.cs
@@ -1,17 +1,17 @@
-﻿using Autofac;
+﻿using System;
+using Autofac;
 using JetBrains.Annotations;
-using System;
 
 namespace Lykke.HttpClientGenerator
 {
     /// <summary>
-    /// Autofac extension to register LimitOperationsCollector job client
+    /// Autofac extension to register refit clients.
     /// </summary>
     [PublicAPI]
     public static class AutofacExtensions
     {
         /// <summary>
-        /// Registers LimitOperationsCollectorJob client.
+        /// Registers Refit client of type <typeparamref name="TInterface"/>.
         /// </summary>
         public static void RegisterClient<TInterface>(
             [NotNull] this ContainerBuilder builder,

--- a/src/Lykke.HttpClientGenerator/Caching/CachingCallsWrapper.cs
+++ b/src/Lykke.HttpClientGenerator/Caching/CachingCallsWrapper.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Newtonsoft.Json;
 using Polly;
 using Polly.Caching;
-using Polly.Caching.MemoryCache;
+using Polly.Caching.Memory;
 
 namespace Lykke.HttpClientGenerator.Caching
 {

--- a/src/Lykke.HttpClientGenerator/Lykke.HttpClientGenerator.csproj
+++ b/src/Lykke.HttpClientGenerator/Lykke.HttpClientGenerator.csproj
@@ -16,11 +16,11 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.8.1" />
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
-    <PackageReference Include="Polly" Version="5.8.0" />
-    <PackageReference Include="Polly.Caching.MemoryCache" Version="1.0.0" />
-    <PackageReference Include="Refit" Version="4.2.0" />
-    <PackageReference Include="System.Reflection.DispatchProxy" Version="4.4.0" />
+    <PackageReference Include="Polly" Version="6.0.1" />
+    <PackageReference Include="Polly.Caching.Memory" Version="2.0.0" />
+    <PackageReference Include="Refit" Version="4.5.6" />
+    <PackageReference Include="System.Reflection.DispatchProxy" Version="4.5.1" />
   </ItemGroup>
 </Project>

--- a/src/Lykke.HttpClientGenerator/Retries/RetryingHttpClientHandler.cs
+++ b/src/Lykke.HttpClientGenerator/Retries/RetryingHttpClientHandler.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -32,7 +31,7 @@ namespace Lykke.HttpClientGenerator.Retries
             _retryPolicy = Policy
                 .Handle<HttpRequestException>()
                 .WaitAndRetryAsync(retryAttemptsCount,
-                    (retryAttempt, context) => retryStrategy.GetRetrySleepDuration(retryAttempt, context.ExecutionKey),
+                    (retryAttempt, context) => retryStrategy.GetRetrySleepDuration(retryAttempt, context.OperationKey),
                     (exception, timeSpan, retryAttempt, context) =>
                         context["RetriesLeft"] = retryAttemptsCount - retryAttempt);
         }

--- a/tests/Lykke.HttpClientGenerator.Tests/Lykke.HttpClientGenerator.Tests.csproj
+++ b/tests/Lykke.HttpClientGenerator.Tests/Lykke.HttpClientGenerator.Tests.csproj
@@ -3,13 +3,13 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.1.1" />
+    <PackageReference Include="FluentAssertions" Version="5.4.0" />
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="Moq" Version="4.8.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Include="Moq" Version="4.8.3" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <PackageReference Include="Refit" Version="4.3.0" />
+    <PackageReference Include="Refit" Version="4.5.6" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Lykke.HttpClientGenerator\Lykke.HttpClientGenerator.csproj">


### PR DESCRIPTION
https://lykkex.atlassian.net/browse/LWDEV-7938

Updated to latest versions of Polly and Refit.

Remark: 6.0.1 version of Polly is incompatible with older versions due to package signing, so thats why we need an updated version of HttpClientGenerator aswell