### PR TITLE
fixed "Generic extension methods ambiguity" issue described here: https://dev.to/lauromoura/generic-extension-methods-ambiguity-in-c-4c7f

### DIFF
--- a/src/Lykke.HttpClientGenerator/HttpClientGeneratorBuilderExtensions.cs
+++ b/src/Lykke.HttpClientGenerator/HttpClientGeneratorBuilderExtensions.cs
@@ -8,48 +8,30 @@ namespace Lykke.HttpClientGenerator
     public static class HttpClientGeneratorBuilderExtensions
     {
         /// <summary>
-        /// Sets a name for this service which will be displayed in all errors
-        /// </summary>
-        ///
-        /// <param name="builder">The builder for the service</param>
-        /// <param name="serviceName">The name of the service</param>
-        ///
-        /// <returns>The service builder</returns>
-        ///
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when <paramref name="builder"/> or <paramref name="serviceName"/> are null
-        /// </exception>
-        public static HttpClientGeneratorBuilder WithServiceName(
-            this HttpClientGeneratorBuilder builder,
-            string serviceName)
-        {
-            return AttachCallsWrapper<object>(builder, serviceName, showReason: false);
-        }
-
-        /// <summary>
         /// Sets a name for this service which will be displayed in all errors,
-        /// additionally parsing and adding service errors
+        /// additionally parsing and adding service errors depending on parameter value
         /// </summary>
-        ///
+        /// 
         /// <param name="builder">The builder for the service</param>
         /// <param name="serviceName">The name of the service</param>
-        ///
+        /// <param name="showReason">Whether to add service errors or not</param>
         /// <typeparam name="T">
         /// The type representing the structure
         /// of the errors returned by the service
         /// </typeparam>
-        ///
+        /// 
         /// <returns>The service builder</returns>
-        ///
+        /// 
         /// <exception cref="ArgumentNullException">
         /// Thrown when <paramref name="builder"/> or <paramref name="serviceName"/> are null
         /// </exception>
         public static HttpClientGeneratorBuilder WithServiceName<T>(
             this HttpClientGeneratorBuilder builder,
-            string serviceName)
+            string serviceName,
+            bool showReason = true)
             where T : class
         {
-            return AttachCallsWrapper<T>(builder, serviceName, showReason: true);
+            return AttachCallsWrapper<T>(builder, serviceName, showReason);
         }
 
         private static HttpClientGeneratorBuilder AttachCallsWrapper<TApiError>(


### PR DESCRIPTION
There is an issue when using overloaded extensions generic methods which leads to the inability for the compiler to resolve the method having just method definition. Removed the overloaded method.