### PR TITLE
Fix case when ApiException.Content does not appears as ErrorResponse.…

### DIFF
--- a/src/Lykke.HttpClientGenerator/Infrastructure/ExceptionHandlerCallsWrapper.cs
+++ b/src/Lykke.HttpClientGenerator/Infrastructure/ExceptionHandlerCallsWrapper.cs
@@ -26,7 +26,14 @@ namespace Lykke.HttpClientGenerator.Infrastructure
                 var errResponse = ex.GetContentAs<ErrorResponse>();
 
                 if (errResponse != null)
+                {
+                    if (errResponse.ErrorMessage == null)
+                    {
+                        errResponse.ErrorMessage = ex.Content;
+                    }
+
                     throw new HttpClientApiException(ex.StatusCode, errResponse);
+                }
 
                 throw;
             }


### PR DESCRIPTION
There was a case when ApiException.Content was
`{"CurrentPage":["The field CurrentPage must be between 1 and 10000."]}`
and this value was transformed into ErrorResponse with all properties = null.
As a result the consuming service was not displaying error message in log and the error message was useless.
After this fix error message in consuming service looks like this:
`Lykke.Logs.Loggers.LykkeSanitizing.SanitizingException: {"CurrentPage":["The field CurrentPage must be between 1 and 10000."]}`